### PR TITLE
fix: consider only changed/added files

### DIFF
--- a/.circleci/phpcs.sh
+++ b/.circleci/phpcs.sh
@@ -38,7 +38,7 @@ git reset --hard -q origin/$target_branch
 git checkout -q $CIRCLE_BRANCH
 
 echo "Getting list of changed files..."
-changed_files=$(git diff --name-only $target_branch..$CIRCLE_BRANCH -- '*.php')
+changed_files=$(git diff --name-only --diff-filter=AM $target_branch..$CIRCLE_BRANCH -- '*.php')
 
 if [[ -z $changed_files ]]
 then


### PR DESCRIPTION
The `git diff --name-only` command may return deleted files, if the
presented changes have at least one of these. So, it's nice to use a
`--diff-filter` for added (A) and modified (M) files only :wink: